### PR TITLE
install_requires for Pillow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ class post_install(install):
 cHeatmap = Extension('cHeatmap', sources=['heatmap/heatmap.c', ])
 
 setup(name='heatmap',
-      version="2.2.1",
+      version="2.2.2",
       description='Module to create heatmaps',
       author='Jeffrey J. Guy',
       author_email='jjg@case.edu',

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(name='heatmap',
       ext_modules=[cHeatmap, ],
       cmdclass={'install': post_install,
                 'build_ext': mybuild},
-      requires=["Pillow", ],
+      install_requires=["Pillow", ],
       test_suite="test",
       tests_require=["Pillow", ],
       )


### PR DESCRIPTION
having requires doesn't pull Pillow as a dependency when installing with
pip. Using install_requires fixes that issue.